### PR TITLE
Added "refresh" feature, and a few missing but known attributes, and improved the documentation slightly

### DIFF
--- a/dist/Discovery.js
+++ b/dist/Discovery.js
@@ -25,7 +25,10 @@ class Discovery {
             version: '',
             platform: '',
             uptime: 0,
-            board: ''
+            softwareId: '',
+            board: '',
+            unpack: 0,
+            interfaceName: ''
         };
         /**
          * Mikrotik FirstByte starts at 8
@@ -57,8 +60,17 @@ class Discovery {
                 case 10: // uptime
                     device.uptime = Buffer.from(this.msg.slice(offset, offset + attrLength)).readUInt32LE(0);
                     break;
+                case 11: // software id
+                    device.softwareId = format_1.bin2String(this.msg.subarray(offset, offset + attrLength));
+                    break;
                 case 12: // board
                     device.board = format_1.bin2String(this.msg.subarray(offset, offset + attrLength));
+                    break;
+                case 14: // unpack (discovery packet compresson type) (none|simple|uncompressed-headers|uncompressed-all)
+                    device.unpack = Buffer.from(this.msg.slice(offset, offset + attrLength)).readInt8(0);
+                    break;
+                case 16: // interface name
+                    device.interfaceName = format_1.bin2String(this.msg.subarray(offset, offset + attrLength));
                     break;
                 default: // unknown type
                     console.debug('unknown mndp message type', attrType);

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -22,4 +22,17 @@ export declare class NodeMndp extends events.EventEmitter {
      * Initalize Listeners
      */
     private registerListeners();
+    /**
+     * Instigate responses from neighbors.
+     *
+     * According to Wireshark on Windows, pressing the Refresh button on Mikrotik's
+     * WinBox tool causes it to send three packets:
+     * 1. to 255.255.255.255
+     * 2. to your subnet's broadcast address, e.g. 192.168.1.255
+     * 3. to 239.255.255.255
+     * The first one works but it causes the server to pick up the packet.
+     * The second one I am not sure how to correctly acquire the IP for, so I skipped.
+     * The third seems to work best because it works without causing our server to react.
+     */
+    refresh(portOverride?: null): void;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -55,5 +55,25 @@ class NodeMndp extends events.EventEmitter {
             this.server.setBroadcast(true);
         });
     }
+    /**
+     * Instigate responses from neighbors.
+     *
+     * According to Wireshark on Windows, pressing the Refresh button on Mikrotik's
+     * WinBox tool causes it to send three packets:
+     * 1. to 255.255.255.255
+     * 2. to your subnet's broadcast address, e.g. 192.168.1.255
+     * 3. to 239.255.255.255
+     * The first one works but it causes the server to pick up the packet.
+     * The second one I am not sure how to correctly acquire the IP for, so I skipped.
+     * The third seems to work best because it works without causing our server to react.
+     */
+    refresh(portOverride = null) {
+        if (!this.started)
+            return;
+        let port = portOverride || this.port;
+        let buf = Buffer.alloc(4);
+        buf.fill(0);
+        this.server.send(buf, 0, 4, port, '239.255.255.255');
+    }
 }
 exports.NodeMndp = NodeMndp;

--- a/dist/interfaces/device.d.ts
+++ b/dist/interfaces/device.d.ts
@@ -5,5 +5,8 @@ export interface Device {
     identity: string;
     platform: string;
     uptime: number;
+    softwareId: string;
     board: string;
+    unpack: number;
+    interfaceName: string;
 }

--- a/lib/Discovery.ts
+++ b/lib/Discovery.ts
@@ -32,7 +32,10 @@ export class Discovery {
             version: '',
             platform: '',
             uptime: 0,
-            board: ''
+            softwareId: '',
+            board: '',
+            unpack: 0,
+            interfaceName: ''
         };
 
         /**
@@ -67,8 +70,17 @@ export class Discovery {
                 case 10: // uptime
                     device.uptime = Buffer.from(this.msg.slice(offset, offset + attrLength)).readUInt32LE(0);
                     break;
+                case 11: // software id
+                    device.softwareId = bin2String(this.msg.subarray(offset, offset + attrLength));
+                    break;
                 case 12: // board
                     device.board = bin2String(this.msg.subarray(offset, offset + attrLength));
+                    break;
+                case 14: // unpack (discovery packet compresson type) (none|simple|uncompressed-headers|uncompressed-all)
+                    device.unpack = Buffer.from(this.msg.slice(offset, offset + attrLength)).readInt8(0);
+                    break;
+                case 16: // interface name
+                    device.interfaceName = bin2String(this.msg.subarray(offset, offset + attrLength));
                     break;
                 default: // unknown type
                     console.debug('unknown mndp message type', attrType);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -78,4 +78,27 @@ export class NodeMndp extends events.EventEmitter {
             this.server.setBroadcast(true);
         })
     }
+
+    /**
+     * Instigate responses from neighbors.
+     * 
+     * According to Wireshark on Windows, pressing the Refresh button on Mikrotik's
+     * WinBox tool causes it to send three packets:
+     * 1. to 255.255.255.255
+     * 2. to your subnet's broadcast address, e.g. 192.168.1.255
+     * 3. to 239.255.255.255
+     * The first one works but it causes the server to pick up the packet.
+     * The second one I am not sure how to correctly acquire the IP for, so I skipped.
+     * The third seems to work best because it works without causing our server to react.
+     */
+    refresh(portOverride=null): void
+    {
+        if (!this.started)
+            return;
+        
+        let port = portOverride || this.port;
+        let buf = Buffer.alloc(4);
+        buf.fill(0);
+        this.server.send(buf, 0, 4, port, '239.255.255.255');
+    }
 }

--- a/lib/interfaces/device.ts
+++ b/lib/interfaces/device.ts
@@ -5,5 +5,8 @@ export interface Device {
     identity: string;
     platform: string;
     uptime: number;
+    softwareId: string;
     board: string;
+    unpack: number;
+    interfaceName: string;
 }

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,12 @@
 
 This is an implementation written in Node
 
+NOTE: The library does **not** automatically send a "refresh" packet to cause neighbors to announce themselves, but the function is implemented and available in the API as `refresh()`.
 
 ### Usage Example
 ```
-var NodeMndp = require('node-mndp');
-var discovery = new NodeMndp({
+var mndp = require('node-mndp').NodeMndp;
+var discovery = new mndp({
     port: 5678
 });
 
@@ -20,8 +21,8 @@ discovery.start();
 
 Ipv6 Example
 ```
-var NodeMndp = require('node-mndp');
-var discovery = new NodeMndp({
+var mndp = require('node-mndp').NodeMndp;
+var discovery = new mndp({
     port: 5678,
     host: "::",
     version: "udp6"
@@ -35,8 +36,8 @@ discovery.start();
 ```
 ### API
 ```
-var NodeMndp = require('node-mndp');
-var discovery = new NodeMndp({
+var mndp = require('node-mndp').NodeMndp;
+var discovery = new mndp({
     port: 5678
 });
 ```
@@ -54,6 +55,8 @@ options {
 
 #### discovery.stop() -> void
 
+#### discovery.refresh() -> void
+
 #### Event: 'deviceFound'
 ```
 
@@ -63,6 +66,12 @@ Output:
     "macAddress":"aabbccddeeff",
     "identity":"Mikrotik",
     "version":"6.41.2 (stable)"
+    "platform":"MikroTik",
+    "uptime":12190,
+    "softwareId":"8C0S-DDXE",
+    "board":"RB2011UiAS-2HnD",
+    "unpack":0,
+    "interfaceName":"LAN_Bridge/ether2"
 }
 
 ```

--- a/test.js
+++ b/test.js
@@ -11,6 +11,7 @@ test.on('deviceFound', (output) => {
 
 test.on('started', (output) => {
     console.log(output);
+    test.refresh();
 });
 
 test.on('error', (output) => {


### PR DESCRIPTION
Hi

Thanks for this nice and simple MNDP implementation. I needed a "refresh" functionality so I implemented that in your library.

I also brought in some more attributes (from wireshark's mndp dissector) into your parser.

I also noticed that the usage instructions were outdated because the library does not export the class directly, so I have updated the readme to match your actual convention (as you use in test.js and I witnessed is also used in prometheus' usage of your library over on https://github.com/patagonaa/prometheus-mndp-autodiscovery/blob/master/src/index.js).

In addition I have documented the refresh function and additional attributes that I've added.

Thanks!